### PR TITLE
Re-roll v2.7.17. [release]

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -4,7 +4,7 @@ FROM cimg/base:2019.11
 
 LABEL maintainer="CircleCI Community/Partner Engineering <community-partner@circleci.com>"
 
-ENV PVENV_ROOT=$HOME/.pyenv \
+ENV PYENV_ROOT=$HOME/.pyenv \
 	PATH=/root/.pyenv/shims:/root/.pyenv/bin:$PATH
 
 RUN apt-get update && apt-get install -y \

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker build --file 3.5/Dockerfile -t cimg/python:3.5.9  -t cimg/python:3.5 .
+docker build --file 2.7/Dockerfile -t cimg/python:2.7.17  -t cimg/python:2.7 .


### PR DESCRIPTION
Re-roll Python v2.7.17. This includes a minor change but more importantly, with the newer release of PyEnv, fixes #19.