### PR TITLE
Publish v3.8.11 and v3.9.6. [release]

### DIFF
--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -32,7 +32,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	curl https://pyenv.run | bash && \
 	sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN pyenv install 3.8.10 && pyenv global 3.8.10
+RUN pyenv install 3.8.11 && pyenv global 3.8.11
 
 RUN python --version && \
 	pip --version && \

--- a/3.8/browsers/Dockerfile
+++ b/3.8/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/python:3.8.10-node
+FROM cimg/python:3.8.11-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/3.8/node/Dockerfile
+++ b/3.8/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/python:3.8.10
+FROM cimg/python:3.8.11
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/3.9/Dockerfile
+++ b/3.9/Dockerfile
@@ -32,7 +32,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	curl https://pyenv.run | bash && \
 	sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN pyenv install 3.9.5 && pyenv global 3.9.5
+RUN pyenv install 3.9.6 && pyenv global 3.9.6
 
 RUN python --version && \
 	pip --version && \

--- a/3.9/browsers/Dockerfile
+++ b/3.9/browsers/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/python:3.9.5-node
+FROM cimg/python:3.9.6-node
 
 LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/3.9/node/Dockerfile
+++ b/3.9/node/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM cimg/python:3.9.5
+FROM cimg/python:3.9.6
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-docker build --file 3.8/Dockerfile -t cimg/python:3.8.10  -t cimg/python:3.8 .
-docker build --file 3.8/node/Dockerfile -t cimg/python:3.8.10-node  -t cimg/python:3.8-node .
-docker build --file 3.8/browsers/Dockerfile -t cimg/python:3.8.10-browsers  -t cimg/python:3.8-browsers .
-docker build --file 3.9/Dockerfile -t cimg/python:3.9.5  -t cimg/python:3.9 .
-docker build --file 3.9/node/Dockerfile -t cimg/python:3.9.5-node  -t cimg/python:3.9-node .
-docker build --file 3.9/browsers/Dockerfile -t cimg/python:3.9.5-browsers  -t cimg/python:3.9-browsers .
+docker build --file 3.8/Dockerfile -t cimg/python:3.8.11  -t cimg/python:3.8 .
+docker build --file 3.8/node/Dockerfile -t cimg/python:3.8.11-node  -t cimg/python:3.8-node .
+docker build --file 3.8/browsers/Dockerfile -t cimg/python:3.8.11-browsers  -t cimg/python:3.8-browsers .
+docker build --file 3.9/Dockerfile -t cimg/python:3.9.6  -t cimg/python:3.9 .
+docker build --file 3.9/node/Dockerfile -t cimg/python:3.9.6-node  -t cimg/python:3.9-node .
+docker build --file 3.9/browsers/Dockerfile -t cimg/python:3.9.6-browsers  -t cimg/python:3.9-browsers .


### PR DESCRIPTION
Waiting for upstream.

For v3.8.11, waiting on PyEnv. I opened a PR: https://github.com/pyenv/pyenv/pull/1993
For v3.9.6, waiting on Python.org. The binaries don't appear to be on the website yet.

Update:

Upstream is now available.