### PR TITLE
Add utility script for PyEnv PRs

### DIFF
--- a/python-hashes.sh
+++ b/python-hashes.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+dURL="https://www.python.org/ftp/python/${1}/Python-${1}"
+
+echo -e "Python v${1} sha256 hashes\n"
+
+echo "XZ tarball:"
+curl -sSL "${dURL}.tar.xz" | sha256sum
+echo ""
+
+echo "Gzip tarball:"
+curl -sSL "${dURL}.tgz" | sha256sum


### PR DESCRIPTION
This image uses PyEnv to install and manage Python versions. Sometimes
PyEnv doesn't get Python versions fast enough and someone from CPE will
submit the PR to the project. In that process, a new file needs to be
created with sha256 hashes for the Python tarball download.

Their docs doesn't tell you that it's sha256 and it has to be done
manually. This PR adds a script to our repo tho spit out the hashes for
you so that you can just copy and paste them. You'd use it by running:

python-hashes.sh <python-version>

for example:

`python-hashes.sh 3.7.10`