### PR TITLE
Update Poetry installation script

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -40,4 +40,4 @@ RUN python --version && \
 	pip install pipenv wheel
 
 # This installs version poetry at the latest version. poetry is updated about twice a month.
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -


### PR DESCRIPTION
An attempt to fix broken poetry installations in `cimg/python:3.10.0` images as described in #100.

Updating the installation script to use the one mentioned on [Poetry's README](https://github.com/python-poetry/poetry#osx--linux--bashonwindows-install-instructions) seems to solve the problem.

Tested locally.

Fixes #100 