### PR TITLE
Enabled shared and respin recent [release]

### DIFF
--- a/3.10/Dockerfile
+++ b/3.10/Dockerfile
@@ -32,7 +32,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	curl https://pyenv.run | bash && \
 	sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN pyenv install 3.10.0 && pyenv global 3.10.0
+RUN env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.10.0 && pyenv global 3.10.0
 
 RUN python --version && \
 	pip --version && \
@@ -40,4 +40,4 @@ RUN python --version && \
 	pip install pipenv wheel
 
 # This installs version poetry at the latest version. poetry is updated about twice a month.
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -

--- a/3.9/Dockerfile
+++ b/3.9/Dockerfile
@@ -32,7 +32,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	curl https://pyenv.run | bash && \
 	sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN pyenv install 3.9.9 && pyenv global 3.9.9
+RUN env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.9.9 && pyenv global 3.9.9
 
 RUN python --version && \
 	pip --version && \
@@ -40,4 +40,4 @@ RUN python --version && \
 	pip install pipenv wheel
 
 # This installs version poetry at the latest version. poetry is updated about twice a month.
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -32,7 +32,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 	curl https://pyenv.run | bash && \
 	sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN pyenv install %%MAIN_VERSION%% && pyenv global %%MAIN_VERSION%%
+RUN env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install %%MAIN_VERSION%% && pyenv global %%MAIN_VERSION%%
 
 RUN python --version && \
 	pip --version && \

--- a/build-images.sh
+++ b/build-images.sh
@@ -3,3 +3,6 @@
 docker build --file 3.9/Dockerfile -t cimg/python:3.9.9  -t cimg/python:3.9 .
 docker build --file 3.9/node/Dockerfile -t cimg/python:3.9.9-node  -t cimg/python:3.9-node .
 docker build --file 3.9/browsers/Dockerfile -t cimg/python:3.9.9-browsers  -t cimg/python:3.9-browsers .
+docker build --file 3.10/Dockerfile -t cimg/python:3.10.0  -t cimg/python:3.10 .
+docker build --file 3.10/node/Dockerfile -t cimg/python:3.10.0-node  -t cimg/python:3.10-node .
+docker build --file 3.10/browsers/Dockerfile -t cimg/python:3.10.0-browsers  -t cimg/python:3.10-browsers .


### PR DESCRIPTION
Build Python with `--enabled-shared` on. Respins v3.9.9 and v3.10.0 to include Poetry fixes from last, community provided, PR.

Fixes #106 
Closes #102