### PR TITLE
Add rustc to Dockerfile.template

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -28,6 +28,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		tk-dev \
 		wget \
 		xz-utils \
+		rustc \
 		zlib1g-dev && \
 	curl https://pyenv.run | bash && \
 	sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
## What does this change do?
This change adds `rustc` ([Rust](https://www.rust-lang.org/) compiler) to `Dockerfile.template`.
`rustc` is installed via `apt-get install` along other packages.
## Why this change is needed?
Rust compiler is required by some of the widely used python libraries, like [cryptography](https://cryptography.io/en/latest/faq/#why-does-cryptography-require-rust).