### PR TITLE
Publish v3.9.14. [release]

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
 
-docker build --file 3.7/Dockerfile -t cimg/python:3.7.14 -t cimg/python:3.7 .
-docker build --file 3.7/node/Dockerfile -t cimg/python:3.7.14-node -t cimg/python:3.7-node .
-docker build --file 3.7/browsers/Dockerfile -t cimg/python:3.7.14-browsers -t cimg/python:3.7-browsers .
-docker build --file 3.8/Dockerfile -t cimg/python:3.8.14 -t cimg/python:3.8 .
-docker build --file 3.8/node/Dockerfile -t cimg/python:3.8.14-node -t cimg/python:3.8-node .
-docker build --file 3.8/browsers/Dockerfile -t cimg/python:3.8.14-browsers -t cimg/python:3.8-browsers .
 docker build --file 3.9/Dockerfile -t cimg/python:3.9.14 -t cimg/python:3.9 .
 docker build --file 3.9/node/Dockerfile -t cimg/python:3.9.14-node -t cimg/python:3.9-node .
 docker build --file 3.9/browsers/Dockerfile -t cimg/python:3.9.14-browsers -t cimg/python:3.9-browsers .
-docker build --file 3.10/Dockerfile -t cimg/python:3.10.7 -t cimg/python:3.10 .
-docker build --file 3.10/node/Dockerfile -t cimg/python:3.10.7-node -t cimg/python:3.10-node .
-docker build --file 3.10/browsers/Dockerfile -t cimg/python:3.10.7-browsers -t cimg/python:3.10-browsers .

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,26 +1,8 @@
 #!/usr/bin/env bash
 # Do not edit by hand; please use build scripts/templates to make changes
-docker push cimg/python:3.7
-docker push cimg/python:3.7.14
-docker push cimg/python:3.7-node
-docker push cimg/python:3.7.14-node
-docker push cimg/python:3.7-browsers
-docker push cimg/python:3.7.14-browsers
-docker push cimg/python:3.8
-docker push cimg/python:3.8.14
-docker push cimg/python:3.8-node
-docker push cimg/python:3.8.14-node
-docker push cimg/python:3.8-browsers
-docker push cimg/python:3.8.14-browsers
 docker push cimg/python:3.9
 docker push cimg/python:3.9.14
 docker push cimg/python:3.9-node
 docker push cimg/python:3.9.14-node
 docker push cimg/python:3.9-browsers
 docker push cimg/python:3.9.14-browsers
-docker push cimg/python:3.10
-docker push cimg/python:3.10.7
-docker push cimg/python:3.10-node
-docker push cimg/python:3.10.7-node
-docker push cimg/python:3.10-browsers
-docker push cimg/python:3.10.7-browsers


### PR DESCRIPTION
For some reason v3.9.14 didn't publish in https://github.com/CircleCI-Public/cimg-python/pull/148 so running it again here.