### PR TITLE
fix(poetry): use new installer

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -45,4 +45,4 @@ RUN python --version && \
 	pip install pipenv wheel
 
 # This installs version poetry at the latest version. poetry is updated about twice a month.
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+RUN curl -sSL https://install.python-poetry.org | python -


### PR DESCRIPTION
Poetry deprecated `install-poetry.py` around 9 months ago, and has since deprecated all installers but the new official one. This seems to also be causing issues for us on "in place" updates of poetry. This swaps out the installer for the new official one. 

See https://github.com/python-poetry/poetry/releases/tag/1.2.0 for more info.