### PR TITLE
Update Pyenv install URL to a more reliable one

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -32,7 +32,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		wget \
 		xz-utils \
 		zlib1g-dev && \
-	curl https://pyenv.run | bash && \
+	curl -sSL "https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer" | bash && \
 	sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN env PYTHON_CONFIGURE_OPTS="--enable-shared --enable-optimizations" pyenv install %%MAIN_VERSION%% && pyenv global %%MAIN_VERSION%%


### PR DESCRIPTION
The recent failures with publishing v3.9.14 show that pyenv.run wasn't returning an IP (or something along those lines). The docs on GitHub say that that vanity URL redirects to this GitHub one so let's just use it directly.

Resource: https://github.com/pyenv/pyenv-installer#install