### PR TITLE
fix: update python-openssl to python3-openssl

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -30,7 +30,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		libxmlsec1-dev \
 		llvm \
 		make \
-		python-openssl \
+		python3-openssl \
 		tk-dev \
 		wget \
 		xz-utils \


### PR DESCRIPTION
builds are breaking as the openssl dependency needed to use python3 rather than python library