### PR TITLE
update: sets pipenv default version to match tagged version of python

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,7 +13,8 @@ LABEL maintainer="Community/Partner Engineering <community-partner@circleci.com>
 
 ENV PYENV_ROOT=/home/circleci/.pyenv \
 	PATH=/home/circleci/.pyenv/shims:/home/circleci/.pyenv/bin:/home/circleci/.poetry/bin:$PATH \
-	PYTHON_VERSION=%%VERSION_FULL%%
+	PYTHON_VERSION=%%VERSION_FULL%% \
+	PIPENV_DEFAULT_PYTHON_VERSION=%%VERSION_FULL%%
 
 RUN sudo apt-get update && sudo apt-get install -y \
 		build-essential \


### PR DESCRIPTION
Closes #167 

- virtualenv cache is using system python. `pipenv --rm` then `pipenv install` fixes this, but is not a good user experience
- pipenv looks for the highest version of python and uses it
- it is not best practice to use the shim path as the python version, which could a factor in why it's not using the right version
- this PR sets a default pipenv version while allowing users to utilize best practice and specify the version if they choose to e.g `pipenv install --python=3.9.15`