### PR TITLE
Add arm64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.1
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,7 +15,9 @@ ENV PYENV_ROOT=/home/circleci/.pyenv \
 	PYTHON_VERSION=%%VERSION_FULL%% \
 	PIPENV_DEFAULT_PYTHON_VERSION=%%VERSION_FULL%%
 
-RUN sudo apt-get update && sudo apt-get install -y \
+USER root
+
+RUN apt-get update && apt-get install -y \
 		build-essential \
 		ca-certificates \
 		curl \
@@ -38,7 +40,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		xz-utils \
 		zlib1g-dev && \
 	curl -sSL "https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer" | bash && \
-	sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN env PYTHON_CONFIGURE_OPTS="--enable-shared --enable-optimizations" pyenv install %%MAIN_VERSION%% && pyenv global %%MAIN_VERSION%%
 
@@ -54,3 +56,5 @@ RUN python --version && \
 
 # This installs version poetry at the latest version. poetry is updated about twice a month.
 RUN curl -sSL https://install.python-poetry.org | python -
+
+USER circleci

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=python
 parent=base
 variants=(node browsers)
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
Add arm64 support to the cimg/python image by using buildx to build multi arch images.

The majority of the work actually lives in the cimg-shared repo which is where the build commands are generated:

https://github.com/CircleCI-Public/cimg-shared/pull/83
https://github.com/CircleCI-Public/cimg-shared/pull/84
https://github.com/CircleCI-Public/cimg-shared/pull/85

The main change to the Dockerfile here is the switch to the `USER` directive. `sudo` in buildx builds generally causes errors when running Docker on linux.

See also changes to cimg-orb:

https://github.com/CircleCI-Public/cimg-orb/pull/51

**Notes for Python:**

The builds with buildx are _super slow_, so I am not 100% happy with the current build workflow for this image in particular. Ideally we need to split this into building on native platforms and combine the manifest, but for now this current solution may work.

---

Note: The browsers variant does not build for arm64, only amd64, due to a limitation with selenium server. We will address this in the future, once arm64 support is rolled out to the majority of images

Test build with buildx: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-python/569/workflows/8cde5db1-d47b-47f1-ba7c-13b343a1879d

# Reasons
To build multi architecture images and allow cimg/python to run on arm64 natively

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
