### PR TITLE
Add arm64 support (v2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cimg: circleci/cimg@0.3.0
+  cimg: circleci/cimg@0.3.3
   slack: circleci/slack@4.12.1
   gh: circleci/github-cli@2.2.0
 

--- a/manifest
+++ b/manifest
@@ -4,3 +4,4 @@ repository=python
 parent=base
 variants=(node browsers)
 namespace=cimg
+arm64=1


### PR DESCRIPTION
# Description
Second attempt at adding arm64 support to the python image

# Reasons
The previous attempt had issues with sudo and to workaround it using the `USER` directive caused permission issues.

The shared module and orb tooling has since been updated with a workaround to allow sudo to work.

The python image in particular is still extremely slow to build, but we will look at ways to mitigate this in the future once arm support has been rolled out to all images

Test build: https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-python/591/workflows/840a4eab-4aa6-445a-8369-601ef09d76a6/jobs/648

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
