### PR TITLE
feat: halt if no changes in most recent dockerfiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,19 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - run:
+          name: Continue if Dockerfiles changed
+          command: |
+            CHANGE="false"
+            source GEN-CHECK
+            for version in "${GEN_CHECK[@]}"; do
+              directory="$(echo "$version" | cut -d '.' -f1).$(echo "$version" | cut -d '.' -f2)"
+              defaultBranch=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+              git diff --quiet "$defaultBranch" -- "$directory" || CHANGE="true"
+            done
+            if [[ $CHANGE != "true" ]]; then
+              circleci step halt
+            fi
       - cimg/build-images:
           docker-namespace: <<parameters.docker-namespace>>
           docker-repository: <<parameters.docker-repository>>


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
- halts the build if there are no changes in the most recent dockerfiles for versions defined in GEN-CHECK
- this also updates and fixes the submodule for automated version checking


# Reasons
Please provide reasoning for these changes and how this PR achieves them.
builds for python specifically can last 3 hours. this makes it so that it only builds when there are changes compared to the default branch

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [N/A] I have made changes to the `Dockerfile.template` file only
- [N/A] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
