### PR TITLE
fix: remove extra v

### DIFF
--- a/pythonFeed.sh
+++ b/pythonFeed.sh
@@ -24,7 +24,6 @@ processLastVersion() {
     directoryCheck "$majorMinor" "$SEARCH_TERM"
     if [[ $(eval echo $?) == 0 ]]; then
         echo "$LATEST_VERSION is valid"
-        VERSIONS+='v'
         VERSIONS+=$LATEST_VERSION
         VERSIONS+=' '
     fi


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
an extra "v" was being added to the version string, breaking checks.

# Reasons
Please provide reasoning for these changes and how this PR achieves them.
removes the extra v

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
