### PR TITLE
Update bot to use cimg/base & install pyenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,12 @@ workflows:
     when: << pipeline.parameters.cron >>
     jobs:
       - cimg/update:
+          pre-steps:
+            - run: echo 'export PYENV_ROOT=/home/circleci/.pyenv' >> "$BASH_ENV"
+            - run: echo 'export PATH=/home/circleci/.pyenv/shims:/home/circleci/.pyenv/bin:$PATH' >> "$BASH_ENV"
+            - run: curl -sSL "https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer" | bash
+
           update-script: pythonFeed.sh
-          image: cimg/python
-          tag: "3.11"
           context:
             - slack-notification-access-token
             - slack-cimg-notifications
@@ -34,7 +37,7 @@ workflows:
             branches:
               ignore:
                 - main
-          context: 
+          context:
             - slack-notification-access-token
             - slack-cimg-notifications
             - cimg-docker-image-building

--- a/pythonFeed.sh
+++ b/pythonFeed.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Update to latest pyenv version
+curl -sSL "https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer" | bash
+
 if [ -f shared/automated-updates.sh ]; then
   source shared/automated-updates.sh
 else


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description

the new version of pyenv is needed to find the newer versions of python. 

Instead of using the version of pyenv in the image, now we update to the latest.

Also using cimg/base now since we're reinstalling pyenv anyway.

# Reasons
Please provide reasoning for these changes and how this PR achieves them.

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
