### PR TITLE
Add uv package manager

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -54,3 +54,6 @@ RUN python --version && \
 
 # This installs version poetry at the latest version. poetry is updated about twice a month.
 RUN curl -sSL https://install.python-poetry.org | python -
+
+# This installs uv at the latest version.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Adds the [uv](https://github.com/astral-sh/uv) package manager to the base image.

# Reasons
`uv` is becoming increasingly popular due to the fast package resolution speed and included batteries. This PR closes #249  uv 

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
