### PR TITLE
Indicate that `uv` is pre-installed in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 `cimg/python` is a Docker image created by CircleCI with continuous integration builds in mind.
 Each tag contains a complete Python version via pyenv.
-pip, pipenv, and poetry are pre-installed, and any binaries and tools that are required for builds to complete successfully in a CircleCI environment.
+pip, pipenv, poetry and uv are pre-installed, and any binaries and tools that are required for builds to complete successfully in a CircleCI environment.
 
 ## Support Policy
 
@@ -52,7 +52,7 @@ You can now use Python within the steps for this job.
 
 ## How This Image Works
 
-This image contains the Python programming language as well as pip, pipenv, and poetry.
+This image contains the Python programming language as well as pip, pipenv, poetry and uv.
 The interpreter is provided via pyenv allowing you to change the Python version during a build as well.
 
 ### Variants


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Indicate that the `uv` package manager comes pre-installed in the image (since https://github.com/CircleCI-Public/cimg-python/pull/257).

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
