### PR TITLE
I compression.zstd module to python 3.14

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -36,7 +36,9 @@ RUN sudo apt-get update && sudo apt-get install -y \
 		tk-dev \
 		wget \
 		xz-utils \
-		zlib1g-dev && \
+		zlib1g-dev \
+		zstd \
+		libzstd-dev && \
 	curl -sSL "https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer" | bash && \
 	sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
# Description
This PR installs the `zstd` and `libzstd-dev` Ubuntu packages into the base layer for the `cimg/python` convenience images.

These libraries are required to enable full functionality of the Python standard library's `compression.zlib` module when Python version 3.14 is installed.

# Reasons
The standard Python 3.14 build process requires the Zstandard compression libraries (`zstd` and `libzstd-dev` on Ubuntu) to successfully build and link the `compression.zlib` module. Without these libraries present in the image, users attempting to use this module on a Python 3.14 environment would encounter build or runtime errors.

Adding these libraries ensures that the Python 3.14 version of `cimg/python` provides a complete and fully functional Python environment, consistent with expectations for CircleCI convenience images.

# Checklist

Please check through the following before opening your PR. Thank you!

- [x] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)