### PR TITLE
Update cimg/base

### DIFF
--- a/manifest
+++ b/manifest
@@ -2,8 +2,8 @@
 
 repository=python
 parent=base
-base_version=2024.02
-new_version=2025.10
+base_version=2026.03-22.04
+new_version=2026.03
 new_tags=(3.14)
 variants=(node browsers)
 namespace=cimg


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Updates the cimg/base versions to the latest available. After this change, I'll rerun the automated workflow to regenerate the pending version updates.
