### PR TITLE
Fix version detection in feed script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,11 @@ workflows:
     when: << pipeline.parameters.cron >>
     jobs:
       - cimg/update:
+          resource_class: small.gen3
           pre-steps:
             - run: echo 'export PYENV_ROOT=/home/circleci/.pyenv' >> "$BASH_ENV"
             - run: echo 'export PATH=/home/circleci/.pyenv/shims:/home/circleci/.pyenv/bin:$PATH' >> "$BASH_ENV"
             - run: curl -sSL "https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer" | bash
-
           update-script: pythonFeed.sh
           context:
             - slack-notification-access-token
@@ -66,7 +66,7 @@ jobs:
   build_and_deploy:
     machine:
       image: ubuntu-2404:current
-    resource_class: 2xlarge+.gen2
+    resource_class: 2xlarge+.gen3
     steps:
       - run:
           name: Install latest QEMU

--- a/pythonFeed.sh
+++ b/pythonFeed.sh
@@ -20,7 +20,8 @@ getPythonVersionLatest() {
 
 processLastVersion() {
     PROCESSED_LATEST_VERSION=$(echo "$LATEST_VERSION" | cut -f1,2 -d'.')
-    VERSION_LIST=$(echo "$VERSION_LIST" | grep -v "$PROCESSED_LATEST_VERSION")
+    ESCAPED_LATEST_VERSION=$(echo "$PROCESSED_LATEST_VERSION" | sed 's/\./\\./g')
+    VERSION_LIST=$(echo "$VERSION_LIST" | grep -v "^${ESCAPED_LATEST_VERSION}\.")
     generateVersions "$LATEST_VERSION"
     generateSearchTerms "PYTHON_VERSION" "$majorMinor"/Dockerfile '\'
       # shellcheck disable=SC2154


### PR DESCRIPTION
# Description
The pythonFeed script wasn't correctly detecting version 3.13.14 (hence https://github.com/CircleCI-Public/cimg-python/pull/311). This updates the script to correctly escape version numbers so we can actually detect them.
